### PR TITLE
Improve readability of Recognize Others section title

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -23,7 +23,7 @@
         - [Improving Rust's compiler messages](./how_to_rustacean/bring_joy/improving_compiler_error.md)
     - [👋 Show up](./how_to_rustacean/show_up.md)
         - [Raising an objection about a design](./how_to_rustacean/show_up/raising_an_objection.md)
-    - [🔭 Recognize others' knowledge](./how_to_rustacean/recognize_others.md)
+    - [🔭 Recognize the knowledge of others](./how_to_rustacean/recognize_others.md)
     - [🔁 Start somewhere](./how_to_rustacean/start_somewhere.md)
     - [✅ Follow through](./how_to_rustacean/follow_through.md)
     - [🤝 Pay it forward](./how_to_rustacean/pay_it_forward.md)

--- a/src/how_to_rustacean.md
+++ b/src/how_to_rustacean.md
@@ -12,7 +12,7 @@
 
 > Bring your expertise and be willing to argue for what you think is right.
 
-## [🔭 Recognize others' knowledge](./how_to_rustacean/recognize_others.md)
+## [🔭 Recognize the knowledge of others](./how_to_rustacean/recognize_others.md)
 
 > Nobody has a monopoly on good ideas. We are always looking for opportunities to improve our designs and seeking input from those with experience and expertise.
 

--- a/src/how_to_rustacean/recognize_others.md
+++ b/src/how_to_rustacean/recognize_others.md
@@ -1,4 +1,3 @@
-# 🔭 Recognize others' knowledge
+# 🔭 Recognize the knowledge of others
 
 > Nobody has a monopoly on good ideas. We are always looking for opportunities to improve our designs and seeking input from those with experience and expertise.
-


### PR DESCRIPTION
I don't know if this is particularly helpful, but I find it a bit easier to read restructured sentences instead of plural possessives. It might also be easier for non-native English speakers.

Feel free to close if it's not relevant!